### PR TITLE
Bump UserData and Nonce field sizes to 1024 bytes

### DIFF
--- a/nitrite.go
+++ b/nitrite.go
@@ -123,8 +123,8 @@ var (
 	ErrBadCABundle                      error = errors.New("Payload 'cabundle' has 0 elements")
 	ErrBadCABundleItem                  error = errors.New("Payload 'cabundle' has a nil item or of length not in [1, 1024]")
 	ErrBadPublicKey                     error = errors.New("Payload 'public_key' has a value of length not in [1, 1024]")
-	ErrBadUserData                      error = errors.New("Payload 'user_data' has a value of length not in [1, 512]")
-	ErrBadNonce                         error = errors.New("Payload 'nonce' has a value of length not in [1, 512]")
+	ErrBadUserData                      error = errors.New("Payload 'user_data' has a value of length not in [1, 1024]")
+	ErrBadNonce                         error = errors.New("Payload 'nonce' has a value of length not in [1, 1024]")
 	ErrBadCertificatePublicKeyAlgorithm error = errors.New("Payload 'certificate' has a bad public key algorithm (not ECDSA)")
 	ErrBadCertificateSigningAlgorithm   error = errors.New("Payload 'certificate' has a bad public key signing algorithm (not ECDSAWithSHA384)")
 	ErrBadSignature                     error = errors.New("Payload's signature does not match signature from certificate")
@@ -279,11 +279,11 @@ func Verify(data []byte, options VerifyOptions) (*Result, error) {
 		return nil, ErrBadPublicKey
 	}
 
-	if nil != doc.UserData && (len(doc.UserData) < 1 || len(doc.UserData) > 512) {
+	if nil != doc.UserData && (len(doc.UserData) < 1 || len(doc.UserData) > 1024) {
 		return nil, ErrBadUserData
 	}
 
-	if nil != doc.Nonce && (len(doc.Nonce) < 1 || len(doc.Nonce) > 512) {
+	if nil != doc.Nonce && (len(doc.Nonce) < 1 || len(doc.Nonce) > 1024) {
 		return nil, ErrBadNonce
 	}
 


### PR DESCRIPTION
The attestation document specification defines the user_data and nonce fields as containing up to 1024 bytes of data, the same size as the cert and public_key fields. Raise the parser limits to reflect the specification.

https://docs.aws.amazon.com/enclaves/latest/user/verify-root.html

Note that the nitro hypervisor doesn't currently enforce this limit, so it's possible to produce attestation documents with a valid signature with more than 1k data in these fields.